### PR TITLE
Fixes related to xetex and luatex support

### DIFF
--- a/beamerouterthemeUniversityOfManchester.sty
+++ b/beamerouterthemeUniversityOfManchester.sty
@@ -32,23 +32,6 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% Declare Images
-\pgfdeclareimage[width=\logowidth]{UoMlogo-white}{TAB_allwhite}
-\pgfdeclareimage[width=\logowidth]{UoMlogo-colour}{TAB_col_white_background}
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% Declare Shadings
-{
-	\pgfdeclareradialshading{UoMbg}{\pgfpoint{0mm}{0mm}}{%
-		color(0mm)=(uompurple);
-		color(.5\paperwidth)=(uompurple!60!black);
-		color(\paperwidth)=(uompurple!60!black)
-	}
-}
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Cull the navigation
 \defbeamertemplate*{navigation symbols}{UniversityOfManchester}{}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -56,19 +39,21 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Headline
 \defbeamertemplate*{headline}{UniversityOfManchester}{%
-	%% Include the Logo
-	\pgftext[at=\pgfpoint{\logopad}{-\logopad}, top, left]{%
-		\ifthenelse{%
-			\boolean{beamer@dark} \OR
-			\( \boolean{beamer@darktitle} \AND \c@framenumber=\beamer@titleframestart \) \OR
-			\boolean{beamer@darkframe}
-		}{%
-			\pgfuseimage{UoMlogo-white}%
-		}{%
-			\pgfuseimage{UoMlogo-colour}%
-		}%
-	}%
-}
+	\begin{tikzpicture}[overlay,remember picture]
+		\node[anchor=north west,yshift=-\logopad,xshift=\logopad]
+		at (current page.north west) {
+			\ifthenelse{%
+				\boolean{beamer@dark} \OR
+				\( \boolean{beamer@darktitle} \AND \c@framenumber=\beamer@titleframestart \) \OR
+				\boolean{beamer@darkframe}
+			}{%
+				\includegraphics[width=\logowidth]{TAB_allwhite}
+			}{%
+				\includegraphics[width=\logowidth]{TAB_col_white_background}
+			}
+		};
+	\end{tikzpicture}}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -155,9 +140,11 @@
 		\( \boolean{beamer@darktitle} \AND \c@framenumber=\beamer@titleframestart \) \OR
 		\boolean{beamer@darkframe}
 	}{%
-		\pgftext[center, at=\pgfpoint{.5\paperwidth}{-.5\paperheight}]{%
-			\pgfuseshading{UoMbg}%
-		}
+		\begin{tikzpicture}
+			\path [outer color = uompurple!60!black,
+			       inner color = uompurple]
+				(0,0) rectangle (\paperwidth,\paperheight);
+		\end{tikzpicture}%
 	}{}
 }
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/beamerthemeUniversityOfManchester.sty
+++ b/beamerthemeUniversityOfManchester.sty
@@ -46,6 +46,7 @@
 	\setstretch{1.2}
 \fi
 \RequirePackage{pgfcore}
+\RequirePackage{tikz}
 
 % Additional work to allow for sections of dark frames
 \newif\ifbeamer@darkframe

--- a/beamerthemeUniversityOfManchester.sty
+++ b/beamerthemeUniversityOfManchester.sty
@@ -35,13 +35,16 @@
 \ProcessOptionsBeamer
 
 % Required Packages
+\RequirePackage{ifthen}
 \ifbeamer@cabin
 	\RequirePackage[sfdefault]{cabin}
-	\RequirePackage[T1]{fontenc}
+	\RequirePackage{ifxetex}
+	\RequirePackage{ifluatex}
+	\ifthenelse{\boolean{xetex}\OR\boolean{luatex}}{}{
+		\RequirePackage[T1]{fontenc}}
 	\RequirePackage{setspace}
 	\setstretch{1.2}
 \fi
-\RequirePackage{ifthen}
 \RequirePackage{pgfcore}
 
 % Additional work to allow for sections of dark frames


### PR DESCRIPTION
The following sample code

``` latex
\documentclass{beamer}
\usetheme[cabin,darktitle]{UniversityOfManchester}
\title{Presentation Title}
\subtitle{Presentation Subtitle}
\author{Author's Name}
\begin{document}
  \frame{\maketitle}
\end{document}
```

produces the following output, when processed via `luatex`:

![before](https://cloud.githubusercontent.com/assets/603082/9439557/7086ada8-4a68-11e5-9592-8fe0ce1c7965.png)

After commit `6fd1672ec6ffb0e5a0d5f6bc72769ce05eb03d22`:

![after](https://cloud.githubusercontent.com/assets/603082/9439434/3eb02026-4a67-11e5-953d-4de8e0b00283.png)
